### PR TITLE
Membership Links

### DIFF
--- a/site/application/controllers/Webhook.php
+++ b/site/application/controllers/Webhook.php
@@ -18,6 +18,11 @@ class Webhook extends CI_Controller {
 		$url = "https://api.github.com/users/UoLCompSoc/repos?per_page=10&client_id=" . $client_id . "&client_secret=" . $client_secret;
 
 		$decoded = json_decode ( $this->_getContent ( $url ) );
+		
+		usort($decoded, function($a, $b)
+        {
+            return ($a->pushed_at < $b->pushed_at);
+        });
 
         $github_data = array();
 

--- a/site/application/controllers/Webhook.php
+++ b/site/application/controllers/Webhook.php
@@ -18,11 +18,6 @@ class Webhook extends CI_Controller {
 		$url = "https://api.github.com/users/UoLCompSoc/repos?per_page=10&client_id=" . $client_id . "&client_secret=" . $client_secret;
 
 		$decoded = json_decode ( $this->_getContent ( $url ) );
-		
-		usort($decoded, function($a, $b)
-        {
-            return ($a->pushed_at < $b->pushed_at);
-        });
 
         $github_data = array();
 

--- a/site/application/views/about_us.php
+++ b/site/application/views/about_us.php
@@ -35,6 +35,11 @@ $this->load->view ( 'include/head_common.php' );
 						<p>But of course, we recognise that it's not all about work, and we have regular scheduled social events both by
 							ourselves and also mixed with other great societies at Leicester, meaning there's always a way for you to get
 							involved.</p>
+						<div>
+	                        <a href="http://www.leicesterunion.com/groups/computing" target="_blank"> <img src="<?=base_url();?>assets/img/joingroup.png"
+		                        alt="Join us at leicesterunion.com!">
+	                        </a>
+	                    </div>
 					</div>
 				</div>
 			</div>

--- a/site/application/views/include/navbar.php
+++ b/site/application/views/include/navbar.php
@@ -49,8 +49,8 @@ defined ( 'BASEPATH' ) or exit ( 'No direct script access allowed' );
 
 				<li><a href="/index.php/login">Register</a></li>
 				<?php endif;?>
-
-
+				
+				<li><a href="http://www.leicesterunion.com/groups/computing" target="_blank">Pay Membership</a></li>
 
 				<li class="dropdown"><a href="#" class="dropdown-toggle" data-toggle="dropdown">Social Media <b class="caret"></b></a>
 					<ul class="dropdown-menu">


### PR DESCRIPTION
Made membership payment more visible to users by adding a link to the Leicester Union group website at http://www.leicesterunion.com/groups/computing in the navbar and on the about us page.
